### PR TITLE
Add support for directory change in warp/iterm2 environments

### DIFF
--- a/lib/command/add.js
+++ b/lib/command/add.js
@@ -32,8 +32,13 @@ class AddCommand extends BaseCommand {
         this.logger.info(`Change directory to ${targetPath}`);
         await this.runScript(script);
         return;
+      } else if (process.env.TERM_PROGRAM === 'Warp') {
+        const script = utils.generateWarpScript(targetPath);
+        this.logger.info(`Change directory to ${targetPath}`);
+        await this.runScript(script);
+        return;
       }
-      this.logger.error('Change directory only supported in darwin');
+      this.logger.error('Change directory only supported in darwin and Warp environments');
     }
 
     try {

--- a/lib/command/find.js
+++ b/lib/command/find.js
@@ -36,8 +36,13 @@ class FindCommand extends BaseCommand {
         this.logger.info(`Change directory to ${dir}`);
         await this.runScript(script);
         return;
+      } else if (process.env.TERM_PROGRAM === 'Warp') {
+        const script = utils.generateWarpScript(dir);
+        this.logger.info(`Change directory to ${dir}`);
+        await this.runScript(script);
+        return;
       }
-      this.logger.error('Change directory only supported in darwin');
+      this.logger.error('Change directory only supported in darwin and Warp environments');
     }
     await this.copyPath(repo, dir);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,9 +11,23 @@ exports.generateAppleScript = dir => {
     end tell
   end tell`.split('\n').map(line => (` -e '${line.trim()}'`)).join('');
 
+  const warpCommand = `tell application "Warp"
+    tell current session of current window
+      write text "cd ${dir}"
+    end tell
+  end tell`.split('\n').map(line => (` -e '${line.trim()}'`)).join('');
+
   const currentApp = `tell application "System Events"
     set activeApp to name of first application process whose frontmost is true
   end tell`.split('\n').map(line => (` -e '${line.trim()}'`)).join('');
 
-  return `[ \`osascript ${currentApp}\` = "Terminal" ] && osascript ${terminalCommand} >/dev/null || osascript ${iTermCommand}`;
+  return `[ \`osascript ${currentApp}\` = "Terminal" ] && osascript ${terminalCommand} >/dev/null || [ \`osascript ${currentApp}\` = "iTerm" ] && osascript ${iTermCommand} >/dev/null || osascript ${warpCommand}`;
+};
+
+exports.generateWarpScript = dir => {
+  return `tell application "Warp"
+    tell current session of current window
+      write text "cd ${dir}"
+    end tell
+  end tell`.split('\n').map(line => (` -e '${line.trim()}'`)).join('');
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "projj",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Manage repository easily.",
   "dependencies": {
     "chalk": "^3.0.0",


### PR DESCRIPTION
Related to #64

Implements support for automatically switching to the corresponding directory in warp/iterm2 environments after adding a project, and updates the version number.

- Adds a new function `generateWarpScript` in `lib/utils.js` to generate a script for changing directories in warp/iterm2 environments.
- Modifies `generateAppleScript` in `lib/utils.js` to include support for warp/iterm2 environments by adding a `warpCommand` script and updating the return statement to execute the appropriate script based on the current terminal application.
- Updates `lib/command/add.js` and `lib/command/find.js` to support changing directories in warp/iterm2 environments by utilizing the updated `generateAppleScript` function. Additionally, introduces a check for the `TERM_PROGRAM` environment variable to determine if the terminal is Warp and uses the `generateWarpScript` function accordingly.
- Increments the version number in `package.json` to 2.2.0 to reflect the new feature addition.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/popomore/projj/issues/64?shareId=a286e645-bc17-40f0-a2fc-8313f99645cb).