### PR TITLE
feat(tasks): rename repo-status → status, keep old name as deprecation shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ projj init                              # one-time setup
 projj add popomore/projj               # clone → ~/projj/github.com/popomore/projj
 projj add git@gitlab.com:team/app.git   # clone → ~/projj/gitlab.com/team/app
 p projj                                 # jump to repo instantly (shell function)
-projj run repo-status --all             # batch operations across all repos
+projj run status --all                  # batch operations across all repos
 ```
 
 ### Shell Integration
@@ -122,7 +122,7 @@ Run a task in the current directory, or all repos with `--all`.
 projj run "npm install"                             # raw command
 projj run update --all                              # named task in all repos
 projj run "git status" --all --match "SeeleAI"      # filter repos by regex
-projj run repo-status -- --detail                   # pass args to task after --
+projj run status -- --detail                        # pass args to task after --
 ```
 
 ### projj list [--raw]
@@ -200,7 +200,7 @@ chmod +x ~/.projj/tasks/notify
 ```bash
 projj run update --all                    # inline task
 projj run notify --all                    # task file
-projj run repo-status -- --detail         # pass arguments after --
+projj run status -- --detail              # pass arguments after --
 projj run "git log -5"                    # raw command (not a named task)
 ```
 
@@ -262,14 +262,14 @@ env = { GIT_USER_NAME = "Other Name", GIT_USER_EMAIL = "other@corp.com" }
 
 Both are optional. Skips if not set.
 
-#### repo-status
+#### status
 
 Shows disk usage, git status, and ignored files for a repo.
 
 ```bash
-projj run repo-status                   # current repo
-projj run repo-status --all             # all repos (quick summary)
-projj run repo-status -- --detail       # include ignored files breakdown
+projj run status                   # current repo
+projj run status --all             # all repos (quick summary)
+projj run status -- --detail       # include ignored files breakdown
 ```
 
 Output example:
@@ -277,9 +277,12 @@ Output example:
 ```text
 📦 1.1G total | 🗃️  .git 2.0M | ✓ clean
 📦 1.1G total | 🗃️  .git 2.0M | ✓ clean | 🚫 15437 ignored: target(1.1G, 99%)
+📦 6.3M total | 🗃️  .git 2.9M | ✎ 22 dirty | 🚫 5 ignored: .claude(1.3M, 21%) skills📂(852K, 13%)
 ```
 
-Colors by size: green (<100M), yellow (100M–1G), red (>1G). Respects `NO_COLOR`.
+Colors by size: green (<100M), yellow (100M–1G), red (>1G). Respects `NO_COLOR`. In the ignored breakdown, a trailing 📂 marks a bucket where only some files inside the top-level directory are ignored (e.g. `skills📂` means "part of `skills/`"), while a bare name like `target` means the whole directory is ignored.
+
+> **Deprecated**: the previous name `repo-status` still works but prints a warning to stderr and delegates to `status`. It will be removed in a future release — please switch to `projj run status`.
 
 #### clean
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -71,10 +71,14 @@ macro_rules! builtin {
 }
 
 /// Registry of built-in tasks. Add new entries here.
+///
+/// `repo-status` is retained as a deprecation shim that execs `status`; it
+/// will be removed in a future release.
 const BUILTINS: &[(&str, &[u8])] = &[
     builtin!("clean"),
     builtin!("git-config-user"),
     builtin!("repo-status"),
+    builtin!("status"),
     builtin!("zoxide"),
 ];
 

--- a/tasks/repo-status
+++ b/tasks/repo-status
@@ -1,128 +1,14 @@
 #!/bin/bash
-# Show repo disk usage, git status, and ignored files summary
-# Usage: repo-status [--fast]  (skip ignored files scan)
+# DEPRECATED: use `projj run status` instead.
+#
+# This shim prints a one-line warning to stderr and then execs the new
+# `status` task with the same arguments. It will be removed in a future
+# release. Migration is a straight rename; no behavior differences.
 
-# Colors (respect NO_COLOR)
-if [ -z "$NO_COLOR" ]; then
-  DIM="\033[2m"
-  RESET="\033[0m"
-  GREEN="\033[32m"
-  YELLOW="\033[33m"
-  RED="\033[31m"
+if [ -z "${NO_COLOR:-}" ]; then
+  printf '\033[33m⚠ projj: `repo-status` is deprecated, use `status` instead\033[0m\n' >&2
 else
-  DIM="" RESET="" GREEN="" YELLOW="" RED=""
+  printf '⚠ projj: `repo-status` is deprecated, use `status` instead\n' >&2
 fi
 
-# Color a size based on KB value: >1G red, >100M yellow, else green
-color_size() {
-  local kb=$1 size=$2
-  if [ "$kb" -ge 1048576 ] 2>/dev/null; then
-    echo -e "${RED}${size}${RESET}"
-  elif [ "$kb" -ge 102400 ] 2>/dev/null; then
-    echo -e "${YELLOW}${size}${RESET}"
-  else
-    echo -e "${GREEN}${size}${RESET}"
-  fi
-}
-
-DETAIL=false
-for arg in "$@"; do
-  [ "$arg" = "--detail" ] && DETAIL=true
-done
-
-total_kb=$(du -sk . 2>/dev/null | cut -f1)
-total=$(du -sh . 2>/dev/null | cut -f1)
-git_kb=$(du -sk .git 2>/dev/null | cut -f1)
-git_size=$(du -sh .git 2>/dev/null | cut -f1)
-dirty=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
-
-colored_total=$(color_size "$total_kb" "$total")
-colored_git=$(color_size "$git_kb" "$git_size")
-
-if [ "$dirty" -eq 0 ]; then
-  dirty_str="${GREEN}✓ clean${RESET}"
-else
-  dirty_str="${YELLOW}✎ ${dirty} dirty${RESET}"
-fi
-
-if [ "$DETAIL" = false ]; then
-  echo -e "📦 ${colored_total} total | 🗃️  .git ${colored_git} | ${dirty_str}"
-  exit 0
-fi
-
-ignored_files=$(git ls-files --others --ignored --exclude-standard 2>/dev/null)
-if [ -n "$ignored_files" ]; then
-  ignored_count=$(echo "$ignored_files" | wc -l | tr -d ' ')
-  # Use --directory so fully-ignored subtrees collapse to a single path while
-  # individual ignored files in otherwise-tracked dirs remain as leaves. Then
-  # du -sk each actual reported path and aggregate by top-level key. This
-  # avoids measuring a whole top-level dir (including its tracked files) just
-  # because one file inside is ignored — e.g. a stray .apk under skills/
-  # shouldn't make skills/ look like a huge ignored blob.
-  #
-  # Perf: collect paths into a bash array and call `du -sk` once with all of
-  # them as arguments rather than forking a du process per entry. On a repo
-  # with hundreds of scattered ignored files this is ~5x faster.
-  ignored_paths=()
-  while IFS= read -r line; do
-    line="${line%/}"
-    [ -z "$line" ] && continue
-    [ -e "$line" ] || continue
-    ignored_paths+=("$line")
-  done < <(git ls-files --others --ignored --exclude-standard --directory 2>/dev/null)
-
-  if [ ${#ignored_paths[@]} -gt 0 ]; then
-    # Single du invocation; one "<kb>\t<path>" line per input path.
-    du_output=$(du -sk -- "${ignored_paths[@]}" 2>/dev/null)
-
-    # Aggregate by top-level key. A bucket is "whole" when none of its
-    # contributing paths contain a slash (meaning git reported the top-level
-    # itself as fully ignored). Otherwise it's a "partial" bucket and we mark
-    # it with a trailing /… in the output.
-    bucket_lines=$(printf '%s\n' "$du_output" | awk -F'\t' '
-      {
-        kb = $1
-        path = $2
-        slash = index(path, "/")
-        if (slash > 0) {
-          key = substr(path, 1, slash - 1)
-          partial[key] = 1
-        } else {
-          key = path
-        }
-        bucket[key] += kb
-      }
-      END {
-        for (k in bucket) {
-          mark = (k in partial) ? "p" : "w"
-          printf "%d\t%s\t%s\n", bucket[k], k, mark
-        }
-      }
-    ' | sort -rn | head -3)
-
-    ignored_dirs=$(printf '%s\n' "$bucket_lines" | while IFS=$'\t' read -r kb key mark; do
-      [ -z "$kb" ] && continue
-      size=$(awk -v k="$kb" 'BEGIN {
-        if (k >= 1048576)      printf "%.1fG", k/1048576
-        else if (k >= 1024)    printf "%.1fM", k/1024
-        else                   printf "%dK", k
-      }')
-      if [ "$total_kb" -gt 0 ] 2>/dev/null; then
-        pct=$((kb * 100 / total_kb))
-      else
-        pct=0
-      fi
-      colored=$(color_size "$kb" "$size")
-      if [ "$mark" = "p" ]; then
-        label="${key}📂"
-      else
-        label="$key"
-      fi
-      echo -ne "${DIM}${label}(${RESET}${colored}${DIM}, ${pct}%)${RESET} "
-    done)
-  fi
-
-  echo -e "📦 ${colored_total} total | 🗃️  .git ${colored_git} | ${dirty_str} | 🚫 ${ignored_count} ignored: ${ignored_dirs}"
-else
-  echo -e "📦 ${colored_total} total | 🗃️  .git ${colored_git} | ${dirty_str} | ✨ 0 ignored"
-fi
+exec "$(dirname -- "$0")/status" "$@"

--- a/tasks/status
+++ b/tasks/status
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Show repo disk usage, git status, and ignored files summary
+# Usage: repo-status [--fast]  (skip ignored files scan)
+
+# Colors (respect NO_COLOR)
+if [ -z "$NO_COLOR" ]; then
+  DIM="\033[2m"
+  RESET="\033[0m"
+  GREEN="\033[32m"
+  YELLOW="\033[33m"
+  RED="\033[31m"
+else
+  DIM="" RESET="" GREEN="" YELLOW="" RED=""
+fi
+
+# Color a size based on KB value: >1G red, >100M yellow, else green
+color_size() {
+  local kb=$1 size=$2
+  if [ "$kb" -ge 1048576 ] 2>/dev/null; then
+    echo -e "${RED}${size}${RESET}"
+  elif [ "$kb" -ge 102400 ] 2>/dev/null; then
+    echo -e "${YELLOW}${size}${RESET}"
+  else
+    echo -e "${GREEN}${size}${RESET}"
+  fi
+}
+
+DETAIL=false
+for arg in "$@"; do
+  [ "$arg" = "--detail" ] && DETAIL=true
+done
+
+total_kb=$(du -sk . 2>/dev/null | cut -f1)
+total=$(du -sh . 2>/dev/null | cut -f1)
+git_kb=$(du -sk .git 2>/dev/null | cut -f1)
+git_size=$(du -sh .git 2>/dev/null | cut -f1)
+dirty=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+
+colored_total=$(color_size "$total_kb" "$total")
+colored_git=$(color_size "$git_kb" "$git_size")
+
+if [ "$dirty" -eq 0 ]; then
+  dirty_str="${GREEN}✓ clean${RESET}"
+else
+  dirty_str="${YELLOW}✎ ${dirty} dirty${RESET}"
+fi
+
+if [ "$DETAIL" = false ]; then
+  echo -e "📦 ${colored_total} total | 🗃️  .git ${colored_git} | ${dirty_str}"
+  exit 0
+fi
+
+ignored_files=$(git ls-files --others --ignored --exclude-standard 2>/dev/null)
+if [ -n "$ignored_files" ]; then
+  ignored_count=$(echo "$ignored_files" | wc -l | tr -d ' ')
+  # Use --directory so fully-ignored subtrees collapse to a single path while
+  # individual ignored files in otherwise-tracked dirs remain as leaves. Then
+  # du -sk each actual reported path and aggregate by top-level key. This
+  # avoids measuring a whole top-level dir (including its tracked files) just
+  # because one file inside is ignored — e.g. a stray .apk under skills/
+  # shouldn't make skills/ look like a huge ignored blob.
+  #
+  # Perf: collect paths into a bash array and call `du -sk` once with all of
+  # them as arguments rather than forking a du process per entry. On a repo
+  # with hundreds of scattered ignored files this is ~5x faster.
+  ignored_paths=()
+  while IFS= read -r line; do
+    line="${line%/}"
+    [ -z "$line" ] && continue
+    [ -e "$line" ] || continue
+    ignored_paths+=("$line")
+  done < <(git ls-files --others --ignored --exclude-standard --directory 2>/dev/null)
+
+  if [ ${#ignored_paths[@]} -gt 0 ]; then
+    # Single du invocation; one "<kb>\t<path>" line per input path.
+    du_output=$(du -sk -- "${ignored_paths[@]}" 2>/dev/null)
+
+    # Aggregate by top-level key. A bucket is "whole" when none of its
+    # contributing paths contain a slash (meaning git reported the top-level
+    # itself as fully ignored). Otherwise it's a "partial" bucket and we mark
+    # it with a trailing /… in the output.
+    bucket_lines=$(printf '%s\n' "$du_output" | awk -F'\t' '
+      {
+        kb = $1
+        path = $2
+        slash = index(path, "/")
+        if (slash > 0) {
+          key = substr(path, 1, slash - 1)
+          partial[key] = 1
+        } else {
+          key = path
+        }
+        bucket[key] += kb
+      }
+      END {
+        for (k in bucket) {
+          mark = (k in partial) ? "p" : "w"
+          printf "%d\t%s\t%s\n", bucket[k], k, mark
+        }
+      }
+    ' | sort -rn | head -3)
+
+    ignored_dirs=$(printf '%s\n' "$bucket_lines" | while IFS=$'\t' read -r kb key mark; do
+      [ -z "$kb" ] && continue
+      size=$(awk -v k="$kb" 'BEGIN {
+        if (k >= 1048576)      printf "%.1fG", k/1048576
+        else if (k >= 1024)    printf "%.1fM", k/1024
+        else                   printf "%dK", k
+      }')
+      if [ "$total_kb" -gt 0 ] 2>/dev/null; then
+        pct=$((kb * 100 / total_kb))
+      else
+        pct=0
+      fi
+      colored=$(color_size "$kb" "$size")
+      if [ "$mark" = "p" ]; then
+        label="${key}📂"
+      else
+        label="$key"
+      fi
+      echo -ne "${DIM}${label}(${RESET}${colored}${DIM}, ${pct}%)${RESET} "
+    done)
+  fi
+
+  echo -e "📦 ${colored_total} total | 🗃️  .git ${colored_git} | ${dirty_str} | 🚫 ${ignored_count} ignored: ${ignored_dirs}"
+else
+  echo -e "📦 ${colored_total} total | 🗃️  .git ${colored_git} | ${dirty_str} | ✨ 0 ignored"
+fi


### PR DESCRIPTION
## Summary
- Renames built-in task \`repo-status\` → \`status\`. The shorter name reads like \`git status\` and doesn't redundantly include "repo".
- Old \`repo-status\` is kept as a thin shim: prints a one-line deprecation warning to stderr and \`exec\`s \`status\` with the same args. Existing user scripts/aliases continue to work.
- Shim will be removed in a future release (no fixed timeline — pure grace period).

**Stacked on** popomore/projj#82 — base branch is \`fix/repo-status-ignored-size\` so the new \`status\` task includes the ignored-size fix, the single-\`du\` perf improvement, and the 📂 partial-bucket marker.

## Changes
- \`tasks/status\`: canonical task (moved from \`tasks/repo-status\` via \`git mv\`)
- \`tasks/repo-status\`: new deprecation shim (14 lines)
- \`src/task.rs\`: register both in \`BUILTINS\`
- \`README.md\`: rename section, add deprecation callout, document the 📂 marker semantics

## Deprecation output

\`\`\`text
\$ projj run repo-status -- --detail
⚠ projj: \`repo-status\` is deprecated, use \`status\` instead
📦 5.0M total | 🗃️  .git 2.9M | ✎ 22 dirty | 🚫 2 ignored: skills📂(852K, 16%)
\`\`\`

Warning goes to stderr (respects \`NO_COLOR\`), so scripts capturing stdout aren't affected.

## Test plan
- [x] \`cargo test\` passes
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`projj run status -- --detail\` produces the same output as before
- [x] \`projj run repo-status -- --detail\` prints warning + delegates correctly
- [x] \`NO_COLOR=1\` variant of the shim
- [x] Exit code propagates through \`exec\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)