### PR TITLE
feat(config): add exclude_dirs to skip directories during repo scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ projj list --raw        # plain paths, one per line (for piping)
 ```toml
 base = ["/Users/x/projj", "/Users/x/work"]
 platform = "github.com"
+exclude_dirs = ["~/Developer/tries"]
 
 [tasks]
 update = "git fetch && git pull origin -p"
@@ -168,6 +169,7 @@ env = { GIT_USER_NAME = "Other Name", GIT_USER_EMAIL = "other@corp.com" }
 |-------|-------------|---------|
 | `base` | Root directory (string or array) | `~/projj` |
 | `platform` | Default host for short form `owner/repo` | `github.com` |
+| `exclude_dirs` | Directories to skip when scanning `base` | `[]` |
 | `tasks` | Named tasks (see [Tasks](#tasks)) | `{}` |
 | `hooks` | Event-driven hooks (see [Hooks](#hooks)) | `[]` |
 

--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -66,6 +66,7 @@ mod tests {
         let config = Config {
             base: BaseDir::Single("/tmp/projj".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks: HashMap::new(),
             hooks: vec![],
         };

--- a/src/cmd/find.rs
+++ b/src/cmd/find.rs
@@ -6,7 +6,7 @@ use crate::select;
 
 pub fn run(keyword: Option<&str>) -> Result<()> {
     let config = Config::load()?;
-    let repos = repo_source::scan(&config.base_dirs())?;
+    let repos = repo_source::scan(&config.base_dirs(), &config.exclude_dirs())?;
     let has_multiple_bases = config.base_dirs().len() > 1;
 
     let matched: Vec<Repo> = if let Some(kw) = keyword {

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -27,6 +27,7 @@ pub fn run() -> Result<()> {
         let config = Config {
             base: BaseDir::Single(base),
             platform,
+            exclude_dirs: Vec::default(),
             tasks: HashMap::default(),
             hooks: vec![HookEntry {
                 event: "post_add".to_string(),
@@ -46,7 +47,7 @@ pub fn run() -> Result<()> {
     task::install_builtins()?;
 
     // Show what was configured
-    let repos = repo_source::scan(&config.base_dirs())?;
+    let repos = repo_source::scan(&config.base_dirs(), &config.exclude_dirs())?;
     eprintln!(
         "📊 {} base directories, {} repositories found",
         config.base_dirs().len(),

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -6,7 +6,7 @@ use crate::select;
 
 pub fn run(raw: bool) -> Result<()> {
     let config = Config::load()?;
-    let repos = repo_source::scan(&config.base_dirs())?;
+    let repos = repo_source::scan(&config.base_dirs(), &config.exclude_dirs())?;
     let has_multiple_bases = config.base_dirs().len() > 1;
 
     if raw {

--- a/src/cmd/remove.rs
+++ b/src/cmd/remove.rs
@@ -11,7 +11,7 @@ use crate::select;
 
 pub fn run(keyword: &str) -> Result<()> {
     let config = Config::load()?;
-    let repos = repo_source::scan(&config.base_dirs())?;
+    let repos = repo_source::scan(&config.base_dirs(), &config.exclude_dirs())?;
     let matched = repo_source::find(&repos, keyword);
 
     if matched.is_empty() {

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -15,7 +15,7 @@ pub fn run(script: &str, all: bool, match_pattern: Option<&str>, args: &[String]
     };
 
     if all {
-        let repos = repo_source::scan(&config.base_dirs())?;
+        let repos = repo_source::scan(&config.base_dirs(), &config.exclude_dirs())?;
 
         // Filter by --match if provided
         let matcher = match match_pattern {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
@@ -10,6 +10,8 @@ pub struct Config {
     pub base: BaseDir,
     #[serde(default = "default_platform")]
     pub platform: String,
+    #[serde(default)]
+    pub exclude_dirs: Vec<String>,
     #[serde(default)]
     pub tasks: HashMap<String, String>,
     #[serde(default)]
@@ -76,27 +78,35 @@ impl Config {
         }
     }
 
+    pub fn exclude_dirs(&self) -> Vec<PathBuf> {
+        self.exclude_dirs.iter().map(PathBuf::from).collect()
+    }
+
     fn resolve_paths(&mut self) {
         let home = dirs::home_dir().unwrap_or_default();
-        let resolve = |s: &str| -> String {
-            if s == "~" {
-                home.to_string_lossy().to_string()
-            } else if let Some(rest) = s.strip_prefix("~/") {
-                home.join(rest).to_string_lossy().to_string()
-            } else if s.starts_with('.') {
-                config_dir().join(s).to_string_lossy().to_string()
-            } else {
-                s.to_string()
-            }
-        };
         match &mut self.base {
-            BaseDir::Single(s) => *s = resolve(s),
+            BaseDir::Single(s) => *s = resolve_path(s, &home),
             BaseDir::Multiple(v) => {
                 for s in v.iter_mut() {
-                    *s = resolve(s);
+                    *s = resolve_path(s, &home);
                 }
             }
         }
+        for s in &mut self.exclude_dirs {
+            *s = resolve_path(s, &home);
+        }
+    }
+}
+
+fn resolve_path(s: &str, home: &Path) -> String {
+    if s == "~" {
+        home.to_string_lossy().to_string()
+    } else if let Some(rest) = s.strip_prefix("~/") {
+        home.join(rest).to_string_lossy().to_string()
+    } else if s.starts_with('.') {
+        config_dir().join(s).to_string_lossy().to_string()
+    } else {
+        s.to_string()
     }
 }
 
@@ -159,6 +169,7 @@ tasks = ["clean"]
         let config = Config {
             base: BaseDir::Single("/tmp/projj".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: vec![],
             tasks: HashMap::new(),
             hooks: vec![],
         };
@@ -170,6 +181,7 @@ tasks = ["clean"]
         let config = Config {
             base: BaseDir::Multiple(vec!["/tmp/a".to_string(), "/tmp/b".to_string()]),
             platform: "github.com".to_string(),
+            exclude_dirs: vec![],
             tasks: HashMap::new(),
             hooks: vec![],
         };
@@ -212,6 +224,31 @@ tasks = ["clean"]
     }
 
     #[test]
+    fn test_parse_exclude_dirs() {
+        let toml = r#"
+base = "/tmp/projj"
+exclude_dirs = ["~/Developer/tries", "/tmp/scratch"]
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config.exclude_dirs,
+            vec!["~/Developer/tries".to_string(), "/tmp/scratch".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_resolve_paths_exclude_dirs_tilde() {
+        let toml = r#"
+base = "/tmp/projj"
+exclude_dirs = ["~/Developer/tries"]
+"#;
+        let mut config: Config = toml::from_str(toml).unwrap();
+        config.resolve_paths();
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(config.exclude_dirs(), vec![home.join("Developer/tries")]);
+    }
+
+    #[test]
     fn test_resolve_paths_multiple() {
         let toml = r#"base = ["~/a", "/b"]"#;
         let mut config: Config = toml::from_str(toml).unwrap();
@@ -241,6 +278,7 @@ tasks = ["clean"]
         let config = Config {
             base: BaseDir::Single("/tmp/projj".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: vec![],
             tasks: HashMap::new(),
             hooks: vec![HookEntry {
                 event: "post_add".to_string(),

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -198,6 +198,7 @@ mod tests {
         let config = Config {
             base: crate::config::BaseDir::Single("/tmp".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks: HashMap::new(),
             hooks: vec![HookEntry {
                 event: "post_add".to_string(),
@@ -217,6 +218,7 @@ mod tests {
         let config = Config {
             base: crate::config::BaseDir::Single("/tmp".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks: HashMap::new(),
             hooks: vec![],
         };
@@ -232,6 +234,7 @@ mod tests {
         let config = Config {
             base: crate::config::BaseDir::Single("/tmp".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks: HashMap::new(),
             hooks: vec![HookEntry {
                 event: "post_add".to_string(),
@@ -255,6 +258,7 @@ mod tests {
         let config = Config {
             base: crate::config::BaseDir::Single("/tmp".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks: HashMap::new(),
             hooks: vec![HookEntry {
                 event: "post_add".to_string(),
@@ -279,6 +283,7 @@ mod tests {
         let config = Config {
             base: crate::config::BaseDir::Single("C:\\tmp".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks: HashMap::new(),
             hooks: vec![HookEntry {
                 event: "post_add".to_string(),
@@ -301,6 +306,7 @@ mod tests {
         let config = Config {
             base: crate::config::BaseDir::Single("/tmp".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks: HashMap::new(),
             hooks: vec![HookEntry {
                 event: "post_add".to_string(),
@@ -323,6 +329,7 @@ mod tests {
         let config = Config {
             base: crate::config::BaseDir::Single("C:\\tmp".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks: HashMap::new(),
             hooks: vec![HookEntry {
                 event: "post_add".to_string(),
@@ -349,6 +356,7 @@ mod tests {
         let config = Config {
             base: crate::config::BaseDir::Single("/tmp".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks,
             hooks: vec![HookEntry {
                 event: "post_add".to_string(),
@@ -369,6 +377,7 @@ mod tests {
         let config = Config {
             base: crate::config::BaseDir::Single("/tmp".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks: HashMap::new(),
             hooks: vec![HookEntry {
                 event: "post_add".to_string(),
@@ -387,6 +396,7 @@ mod tests {
         let config = Config {
             base: crate::config::BaseDir::Single("/tmp".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks: HashMap::new(),
             hooks: vec![HookEntry {
                 event: "post_add".to_string(),
@@ -407,6 +417,7 @@ mod tests {
         let config = Config {
             base: crate::config::BaseDir::Single("/tmp".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks: HashMap::new(),
             hooks: vec![HookEntry {
                 event: "post_add".to_string(),
@@ -431,6 +442,7 @@ mod tests {
         let config = Config {
             base: crate::config::BaseDir::Single("/tmp".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks: HashMap::new(),
             hooks: vec![HookEntry {
                 event: "post_add".to_string(),
@@ -453,6 +465,7 @@ mod tests {
         let config = Config {
             base: crate::config::BaseDir::Single("/tmp".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks: HashMap::new(),
             hooks: vec![HookEntry {
                 event: "post_add".to_string(),

--- a/src/repo_source.rs
+++ b/src/repo_source.rs
@@ -30,19 +30,19 @@ impl Repo {
 
 /// Scan base directories for git repositories.
 /// Fixed depth: base/host/owner/repo/.git
-pub fn scan(base_dirs: &[PathBuf]) -> Result<Vec<Repo>> {
+pub fn scan(base_dirs: &[PathBuf], exclude: &[PathBuf]) -> Result<Vec<Repo>> {
     let mut repos = Vec::new();
     for base in base_dirs {
         if !base.exists() {
             continue;
         }
-        scan_base(base, &mut repos)?;
+        scan_base(base, exclude, &mut repos)?;
     }
     repos.sort_by(|a, b| a.path.cmp(&b.path));
     Ok(repos)
 }
 
-fn scan_base(base: &Path, repos: &mut Vec<Repo>) -> Result<()> {
+fn scan_base(base: &Path, exclude: &[PathBuf], repos: &mut Vec<Repo>) -> Result<()> {
     let base_path = base.to_path_buf();
     // Level 1: host (github.com, gitlab.com, ...)
     let Ok(hosts) = std::fs::read_dir(base) else {
@@ -54,7 +54,7 @@ fn scan_base(base: &Path, repos: &mut Vec<Repo>) -> Result<()> {
             continue;
         }
         let host_name = host_entry.file_name().to_string_lossy().to_string();
-        if host_name.starts_with('.') {
+        if host_name.starts_with('.') || exclude.iter().any(|e| e == &host_entry.path()) {
             continue;
         }
 
@@ -68,7 +68,7 @@ fn scan_base(base: &Path, repos: &mut Vec<Repo>) -> Result<()> {
                 continue;
             }
             let owner_name = owner_entry.file_name().to_string_lossy().to_string();
-            if owner_name.starts_with('.') {
+            if owner_name.starts_with('.') || exclude.iter().any(|e| e == &owner_entry.path()) {
                 continue;
             }
 
@@ -82,7 +82,7 @@ fn scan_base(base: &Path, repos: &mut Vec<Repo>) -> Result<()> {
                     continue;
                 }
                 let repo_name = repo_entry.file_name().to_string_lossy().to_string();
-                if repo_name.starts_with('.') {
+                if repo_name.starts_with('.') || exclude.iter().any(|e| e == &repo_entry.path()) {
                     continue;
                 }
 
@@ -211,7 +211,7 @@ mod tests {
     #[test]
     fn test_scan_empty_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let repos = scan(&[dir.path().to_path_buf()]).unwrap();
+        let repos = scan(&[dir.path().to_path_buf()], &[]).unwrap();
         assert!(repos.is_empty());
     }
 
@@ -220,7 +220,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let repo_path = dir.path().join("github.com/popomore/projj/.git");
         std::fs::create_dir_all(&repo_path).unwrap();
-        let repos = scan(&[dir.path().to_path_buf()]).unwrap();
+        let repos = scan(&[dir.path().to_path_buf()], &[]).unwrap();
         assert_eq!(repos.len(), 1);
         assert_eq!(repos[0].host, "github.com");
         assert_eq!(repos[0].owner, "popomore");
@@ -233,8 +233,19 @@ mod tests {
         std::fs::create_dir_all(dir.path().join(".hidden/owner/repo/.git")).unwrap();
         std::fs::create_dir_all(dir.path().join("github.com/.hidden/repo/.git")).unwrap();
         std::fs::create_dir_all(dir.path().join("github.com/owner/.hidden/.git")).unwrap();
-        let repos = scan(&[dir.path().to_path_buf()]).unwrap();
+        let repos = scan(&[dir.path().to_path_buf()], &[]).unwrap();
         assert!(repos.is_empty());
+    }
+
+    #[test]
+    fn test_scan_skips_excluded_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("tries/x/y/.git")).unwrap();
+        std::fs::create_dir_all(dir.path().join("github.com/owner/repo/.git")).unwrap();
+        let exclude = vec![dir.path().join("tries")];
+        let repos = scan(&[dir.path().to_path_buf()], &exclude).unwrap();
+        assert_eq!(repos.len(), 1);
+        assert_eq!(repos[0].host, "github.com");
     }
 
     #[test]
@@ -242,13 +253,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         // No .git directory
         std::fs::create_dir_all(dir.path().join("github.com/owner/repo")).unwrap();
-        let repos = scan(&[dir.path().to_path_buf()]).unwrap();
+        let repos = scan(&[dir.path().to_path_buf()], &[]).unwrap();
         assert!(repos.is_empty());
     }
 
     #[test]
     fn test_scan_nonexistent_base() {
-        let repos = scan(&[PathBuf::from("/nonexistent/path")]).unwrap();
+        let repos = scan(&[PathBuf::from("/nonexistent/path")], &[]).unwrap();
         assert!(repos.is_empty());
     }
 
@@ -258,7 +269,7 @@ mod tests {
         let dir2 = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir1.path().join("github.com/a/repo1/.git")).unwrap();
         std::fs::create_dir_all(dir2.path().join("gitlab.com/b/repo2/.git")).unwrap();
-        let repos = scan(&[dir1.path().to_path_buf(), dir2.path().to_path_buf()]).unwrap();
+        let repos = scan(&[dir1.path().to_path_buf(), dir2.path().to_path_buf()], &[]).unwrap();
         assert_eq!(repos.len(), 2);
     }
 
@@ -268,7 +279,7 @@ mod tests {
         // A file where a host dir should be
         std::fs::write(dir.path().join("not-a-dir"), "").unwrap();
         std::fs::create_dir_all(dir.path().join("github.com/owner/repo/.git")).unwrap();
-        let repos = scan(&[dir.path().to_path_buf()]).unwrap();
+        let repos = scan(&[dir.path().to_path_buf()], &[]).unwrap();
         assert_eq!(repos.len(), 1);
     }
 
@@ -277,7 +288,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join("github.com")).unwrap();
         std::fs::write(dir.path().join("github.com/not-a-dir"), "").unwrap();
-        let repos = scan(&[dir.path().to_path_buf()]).unwrap();
+        let repos = scan(&[dir.path().to_path_buf()], &[]).unwrap();
         assert!(repos.is_empty());
     }
 
@@ -286,7 +297,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join("github.com/owner")).unwrap();
         std::fs::write(dir.path().join("github.com/owner/not-a-dir"), "").unwrap();
-        let repos = scan(&[dir.path().to_path_buf()]).unwrap();
+        let repos = scan(&[dir.path().to_path_buf()], &[]).unwrap();
         assert!(repos.is_empty());
     }
 
@@ -295,7 +306,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join("github.com/z/repo/.git")).unwrap();
         std::fs::create_dir_all(dir.path().join("github.com/a/repo/.git")).unwrap();
-        let repos = scan(&[dir.path().to_path_buf()]).unwrap();
+        let repos = scan(&[dir.path().to_path_buf()], &[]).unwrap();
         assert_eq!(repos.len(), 2);
         assert!(repos[0].path < repos[1].path);
     }
@@ -304,7 +315,7 @@ mod tests {
     fn test_scan_sets_base_field() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join("github.com/owner/repo/.git")).unwrap();
-        let repos = scan(&[dir.path().to_path_buf()]).unwrap();
+        let repos = scan(&[dir.path().to_path_buf()], &[]).unwrap();
         assert_eq!(repos[0].base, dir.path());
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -115,6 +115,7 @@ mod tests {
         Config {
             base: BaseDir::Single("/tmp".to_string()),
             platform: "github.com".to_string(),
+            exclude_dirs: Vec::new(),
             tasks: HashMap::new(),
             hooks: vec![],
         }


### PR DESCRIPTION
Scratch project dirs (e.g. try-rs output) can sit under base and coincidentally match the host/owner/repo shape, so they show up as managed repos. exclude_dirs lets a directory be named in config.toml to skip entirely, checked at each level scan walks.


Thanks for making a great tool, and this would be the icing on the cake for me :) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `exclude_dirs` configuration option for specifying directories to skip during repository discovery.
  * Repository searches and management commands now honor configured exclusions.
  * Added support for resolving excluded paths using configured path formats.

* **Documentation**
  * Documented `exclude_dirs` in the example configuration and configuration reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->